### PR TITLE
Automated nightly builds

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -31,4 +31,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: PDF
-          path: main.pdf
+          path: ./book/main.pdf

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Tex compile
         uses: xu-cheng/latex-action@v3
         with:
+          working_directory: book
           root_file: main.tex
           extra_fonts: |
-            .book/fonts
+            ./fonts

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -24,5 +24,6 @@ jobs:
         with:
           working_directory: book
           root_file: main.tex
+          compiler: xelatex
           extra_fonts: |
             ./fonts

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -27,8 +27,10 @@ jobs:
           latexmk_use_xelatex: true
           extra_fonts: |
             ./fonts
-      - name: Upload PDF file
-        uses: actions/upload-artifact@v4
+      - name: Update nightly release
+        uses: eine/tip@master
         with:
-          name: PDF
-          path: ./book/main.pdf
+          tag: nightly
+          rm: true
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+          files: ./book/main.pdf

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,21 @@
+name: development build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tex compile
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: main.tex
+          extra_fonts: |
+            .book/fonts

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -24,6 +24,11 @@ jobs:
         with:
           working_directory: book
           root_file: main.tex
-          compiler: xelatex
+          latexmk_use_xelatex: true
           extra_fonts: |
             ./fonts
+      - name: Upload PDF file
+        uses: actions/upload-artifact@v4
+        with:
+          name: PDF
+          path: main.pdf

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,16 +3,22 @@ name: development build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v2
+        with: 
+          # Fine-grained PAT with contents:write and workflows:write scopes
+          token: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Tex compile
         uses: xu-cheng/latex-action@v3
         with:


### PR DESCRIPTION
Added a workflow definition that automatically builds a new PDF version when pushing to main or on PR. 

The resulting PDF is uploaded to a static "pre-release" so we can have a single stable URL to link to in the README file afterwards.

Note: 
- this will require us to manually create the "nightly" release first.
- not sure if a new workflow token will have to be set up (I did do it in my fork first)