### PR TITLE
Replacing FPR to FNR in the FNR section

### DIFF
--- a/book/3-classification.tex
+++ b/book/3-classification.tex
@@ -140,9 +140,9 @@ Use FNR when the cost of missing positive cases is high (e.g., in medical diagno
 % Left text with the image on the right
 \textbf{Figure 3.1 False Negative Rate.} 
 \textbf{Top:}
-3D surface illustrating FPR's non-linear relationship with FP and TN. FPR is lowest (blue) when FP is low. It increases (red) as FP increases.
+3D surface illustrating FNR's non-linear relationship with FN and TP. FNR is lowest (blue) when FN is low. It increases (red) as FN increases.
 \textbf{Right:}
-Shows how FPR decreases hyperbolically as total negative cases increase for fixed FP values. Lower FP maintains better FPR.
+Shows how FNR decreases hyperbolically as total positive cases increase for fixed FN values. Lower FN maintains better FNR.
 
 
 \orangebox{%
@@ -152,9 +152,9 @@ Did you know that...}
     This demonstrates the inherent trade-off between Type I and Type II errors in statistical testing.
 }
 
-\textbf{FPR alternatives and related metrics}
+\textbf{FNR alternatives and related metrics}
 
-Other metrics used alongside or instead True Positive Rate (TPR/Recall/Sensitivity), Specificity, Precision, F1-Score, and ROC curve.
+Other metrics used alongside or instead of False Negative Rate (TPR/Recall/Sensitivity), Specificity, Precision, F1-Score, and ROC curve.
 
 % ---------- FNR ----------
 \clearpage


### PR DESCRIPTION
Missed replacing FPR to FNR in the FNR metric section.