### PR TITLE
Added MSLE formulae with annotations

### DIFF
--- a/book/2-regression.tex
+++ b/book/2-regression.tex
@@ -165,7 +165,7 @@ It measures the average of the squared differences between the logarithms of the
         \node[inner sep=2pt, font=\Large] (a) {
             {
                 $\displaystyle
-                MSLE = \frac{1}{{\color{nmlred}n}} \sum_{t=1}^n \left(\log({\color{nmlcyan}Y_t} + 1) - \log({\color{nmlpurple}\hat{Y}_t} + 1)\right)^2
+                MSLE = \frac{1}{{\color{nmlred}n}} \sum_{t=1}^n \left(log({\color{nmlcyan}Y_t} + 1) - log({\color{nmlpurple}\hat{Y}_t} + 1)\right)^2
                 $
             }
         };

--- a/book/2-regression.tex
+++ b/book/2-regression.tex
@@ -161,9 +161,20 @@ It measures the average of the squared differences between the logarithms of the
 
 % formula
 \begin{center}
-    [FORMULA GOES HERE]
+    \tikz{
+        \node[inner sep=2pt, font=\Large] (a) {
+            {
+                $\displaystyle
+                MSLE = \frac{1}{{\color{nmlred}n}} \sum_{t=1}^n \left(\log({\color{nmlcyan}Y_t} + 1) - \log({\color{nmlpurple}\hat{Y}_t} + 1)\right)^2
+                $
+            }
+        };
+        \draw[-latex,nmlred, semithick] ($(a.south)+(-2.6,0.4)$) to[bend left=15] node[pos=1, left,align=center] {number\\of samples} +(-1,-.5);
+        \draw[-latex,nmlpurple, semithick] ($(a.north)+(3.1,-0.3)$) to[bend left=15] node[pos=1, right] {forecast value} +(1,.5); 
+        \draw[-latex,nmlcyan, semithick] ($(a.south)+(0.1,0.5)$) to[bend right=15] node[pos=1, right] {actual value} +(1,-.5);
+        }
 \end{center}
-    
+
 MSLE is always a positive value, with a smaller MSLE indicating better forecast accuracy. Theoretically, MSLE belongs in the 0 to +infinity range.
 
 \textbf{When to use MSLE?}


### PR DESCRIPTION
This PR addresses issue [#117](https://github.com/NannyML/The-Little-Book-of-ML-Metrics/issues/117), which required adding the MSLE (Mean Squared Logarithmic Error) formula to the LaTeX file, following the formatting and styling of the provided MSE formula example.

![image](https://github.com/user-attachments/assets/b86c5055-0fd0-4d6e-8520-c0a736d313c6)

