### PR TITLE
Added Explained Variance Score Formula

### DIFF
--- a/book/2-regression.tex
+++ b/book/2-regression.tex
@@ -544,9 +544,9 @@ of events occurring in a fixed time or space (e.g., website clicks per hour, pho
                 $
             }
         };
-        \draw[-latex,nmlred, semithick] ($(a.south)+(-2.2,0)$) to[bend left=15] node[pos=1, left] {number of samples} +(-1,-1);
-        \draw[-latex,nmlpurple, semithick] ($(a.north)+(0,0.0)$) to[bend left=15] node[pos=1, right] {actual value} +(1.5,.5); 
-        \draw[-latex,nmlcyan, semithick] ($(a.south)+(1.3,0)$) to[bend right=15] node[pos=1, right] {predicted value} +(1.5,-1);
+        \draw[-latex,nmlred, semithick] ($(a.south)+(-2.2,0.2)$) to[bend left=15] node[pos=1, left] {number of samples} +(-1,-0.5);
+        \draw[-latex,nmlpurple, semithick] ($(a.north)+(1.3,0.0)$) to[bend left=15] node[pos=1, right] {actual value} +(1,.5); 
+        \draw[-latex,nmlcyan, semithick] ($(a.south)+(1.3,0)$) to[bend right=15] node[pos=1, right] {predicted value} +(1,-0.5);
     }
 \end{center}
 
@@ -809,12 +809,23 @@ The plot shows how the loss increases linearly with the difference between the p
 \section{Explained Variance Score}
 \subsection{Explained Variance Score}
 
-The Explained Variance Score is a regression evaluation metric that measures the proportion of variance in the target variable that is captured by the model’s predictions.
+The Explained Variance Score (EVS) is a regression evaluation metric that measures the proportion of variance in the target variable that is captured by the model’s predictions.
 It focuses specifically on how well the variability of the data is explained, rather than penalizing systematic biases or a lack of correlation between true and predicted values.
 
 % formula
 \begin{center}
-    [FORMULA GOES HERE]
+    \tikz{
+        \node[inner sep=2pt, font=\Large] (a) {
+            {
+                $\displaystyle
+                EVS = 1 - \frac{Var({\color{nmlcyan}Y} - {\color{nmlpurple}\hat{Y}})}{Var({\color{nmlcyan}Y})}
+                $
+            }
+        };
+        
+        \draw[-latex,nmlcyan, semithick] ($(a.north)+(1.2,0)$) to[bend right=15] node[pos=1, left] {actual value} +(-1,.5);
+        \draw[-latex,nmlpurple, semithick] ($(a.north)+(2.3,0)$) to[bend left=15] node[pos=1, right] {predicted value} +(1,.5); 
+    }
 \end{center}
 
 Explained Variance Score ranges from -infinity to 1, with 1 indicating that the model explains all variability in the target variable. Negative values suggest the model performs worse


### PR DESCRIPTION
### Closes: #128 

This PR adds the formula of Explained Variance Score to the Regression section.

<img width="359" alt="image" src="https://github.com/user-attachments/assets/78052733-8b6e-4d1d-8f5d-a7e4a5438918">

Also fixed positioning of arrows in MPD formula.